### PR TITLE
Some API and style changes.

### DIFF
--- a/src/ImgHdr.jl
+++ b/src/ImgHdr.jl
@@ -158,8 +158,9 @@ push!(tests,isa_pgm)
 function isa_ppm(f)
     h=_read(f)
     if length(h) >= 3 && h[1] == 'P' && occursin(h[2],"36") && occursin(h[3],"\t\n\r")
-        return "ppm"
+        return true
     end
+    return false
 end
 
 push!(tests,isa_ppm)

--- a/src/ImgHdr.jl
+++ b/src/ImgHdr.jl
@@ -1,11 +1,11 @@
+"Check image headers to determine image format."
 module ImgHdr
-export check
 
-"""
-    Read content of the file and returns collection of U8s
+export imgtype
 
-"""
-function what(file)
+
+"Read content of the file and data as `Array{UInt8}`."
+function _read(file)
     try  
         open(file, "r") do s 
             return read(s,String)  
@@ -15,136 +15,157 @@ function what(file)
     end 
 end
 
-
 const tests = Function[]
 
-function test_gif(f)
-    h=what(f)
+
+function isa_gif(f)
+    h=_read(f)
     if h[1:6] == "GIF87a" || h[1:6] == "GIF89a"
-        return "gif"
+        return true
     end
+    return false
 end
 
-push!(tests,test_gif)
+push!(tests,isa_gif)
 
 
-function test_jpeg(f)
-    h=what(f)
+function isa_jpeg(f)
+    h=_read(f)
     if h[7:10] == "JFIF" || h[7:10] =="Exif"
-        return "jpeg"
+        return true
     end
+    return false
 end
      
-push!(tests,test_jpeg)
+push!(tests,isa_jpeg)
 
-function test_rgb(f)
-    h=what(f)
-    """SGI image library"""
+
+"SGI image library"
+function isa_rgb(f)
+    h=_read(f)
     if startswith(h,"\001\332")
-        return "rgb"
+        return true
     end
+    return false
 end
 
-push!(tests,test_rgb)
+push!(tests,isa_rgb)
 
 
-
-function test_tiff(f)
-    h=what(f)
+function isa_tiff(f)
+    h=_read(f)
     if h[1:2] == "MM" || h[1:2] == "II"
-        return "tiff"
+        return true
     end
+    return false
 end
 
-push!(tests,test_tiff)
+push!(tests,isa_tiff)
    
-function test_webp(f)
-    h=what(f)
+
+function isa_webp(f)
+    h=_read(f)
     if startswith(h, "RIFF") && h[9:12] == "WEBP"
-        return "webp"
+        return true
     end
+    return false
 end
 
-push!(tests,test_webp)
+push!(tests,isa_webp)
 
-function test_png(f)
-    h=what(f)
+
+function isa_png(f)
+    h=_read(f)
     if startswith(h,"\x89PNG\r\n\x1a\n")
-        return "png"
+        return true
     end
+    return false
 end
 
-push!(tests,test_png)
+push!(tests,isa_png)
  
-function test_exr(f)
-    h=what(f)
+
+function isa_exr(f)
+    h=_read(f)
     if startswith(h,"\x76\x2f\x31\x01")
-        return "exr"
+        return true
     end
+    return false
 end
 
-push!(tests,test_exr)
+push!(tests,isa_exr)
 
-function test_xbm(f)
-    """X bitmap (X10 or X11)"""
-    h=what(f)
+
+"X bitmap (X10 or X11)"
+function isa_xbm(f)
+    h=_read(f)
     if startswith(h,"#define ")
-        return "xbm"
+        return true
     end
+    return false
 end
-push!(tests,test_xbm)
+push!(tests,isa_xbm)
 
-function test_pbm(f)
-    """PBM (portable bitmap)"""
-    h=what(f)
+
+"PBM (portable bitmap)"
+function isa_pbm(f)
+    h=_read(f)
     if length(h) >= 3 && h[1] == 'P' && occursin(h[2],"14") && occursin(h[3],"\t\n\r")
-        return "pbm"
+        return true
     end
+    return false
 end
 
-push!(tests,test_pbm)
+push!(tests,isa_pbm)
 
-function test_rast(f)
-    """Sun raster file"""
-    h=what(f)
+
+"Sun raster file"
+function isa_rast(f)
+    h=_read(f)
     if startswith(h,"\x59\xA6\x6A\x95")
-        return "rast"
+        return return true
     end
+    return false
 end
 
-push!(tests,test_rast)
+push!(tests,isa_rast)
 
-function test_bmp(f)
-    h=what(f)
+
+function isa_bmp(f)
+    h=_read(f)
     if startswith(h,"BM")
-        return "bmp"
+        return true
     end
+    return false
 end
 
-push!(tests,test_bmp)
+push!(tests,isa_bmp)
 
 
-function test_pgm(f)
-    """PGM (portable graymap)"""
-    h=what(f)
+"PGM (portable graymap)"
+function isa_pgm(f)
+    h=_read(f)
     if length(h) >= 3 && h[1] == 'P' && occursin(h[2],"25") && occursin(h[3],"\t\n\r")
-        return "pgm"
+        return true
     end
+    return false
 end
 
-push!(tests,test_pgm)
+push!(tests,isa_pgm)
 
-function test_ppm(f)
-    """PPM (portable pixmap)"""
-    h=what(f)
+
+"PPM (portable pixmap)"
+function isa_ppm(f)
+    h=_read(f)
     if length(h) >= 3 && h[1] == 'P' && occursin(h[2],"36") && occursin(h[3],"\t\n\r")
         return "ppm"
     end
 end
 
-push!(tests,test_ppm)
+push!(tests,isa_ppm)
 
-println(length(tests))
+
+# println(length(tests))
 
 """
        ImgHdr.check(path/to/file)
@@ -157,13 +178,14 @@ println(length(tests))
        "gif"
        ```
 """
-function check(filename::String)
-    for i in tests
-        p=i(filename)
-        if p != nothing
-            return p
+function imgtype(filename::String)
+    for f in tests
+        p=f(filename)
+        if p
+            return split(string(f), '_')[2]
         end
     end
+    return nothing  # just make it explicit
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ using Test: @testset, @test, @test_throws
 
     @test ImgHdr.isa_gif(gif)
     @test imgtype(gif) == "gif"
-    @test imgtype(png) != "png"
+    @test imgtype(gif) != "png"
 
     jpeg = "images/example.jpeg"
     @test ImgHdr.isa_jpeg(jpeg)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,17 +1,74 @@
-using ImgHdr, Test
+using ImgHdr: imgtype
+using Test: @testset, @test, @test_throws
 
-@testset "test_images" begin
-    @test check("images/example.png") == "png"
-    @test check("images/example.gif") == "gif"
-    @test check("images/example.jpeg") == "jpeg"
-    @test check("images/example.exr") == "exr"
-    @test check("images/example.tiff") == "tiff"
-    @test check("images/example.webp") == "webp"
-    @test check("images/example.pbm") == "pbm"
-    @test check("images/example.xbm") == "xbm"
-    @test check("images/example.bmp") == "bmp"
-    @test check("images/example.pgm") == "pgm"
-    @test check("images/example.ppm") == "ppm"
-    @test check("images/example.ras") == "rast"
-    @test_throws MethodError check("ait")
+@testset "test_images_types" begin
+    png = "images/example.png"
+    gif = "images/example.gif"
+
+    @test ImgHdr.isa_png(png)
+    @test imgtype(png) == "png"
+    @test imgtype(png) != "gif"
+
+    @test ImgHdr.isa_gif(gif)
+    @test imgtype(gif) == "gif"
+    @test imgtype(png) != "png"
+
+    jpeg = "images/example.jpeg"
+    @test ImgHdr.isa_jpeg(jpeg)
+    @test imgtype(jpeg) == "jpeg"
+    @test imgtype(jpeg) != "pgn"
+
+    exr = "images/example.exr"
+    @test ImgHdr.isa_exr(exr)
+    @test imgtype(exr) == "exr"
+    @test imgtype(exr) != "gif"
+
+    tiff = "images/example.tiff"
+    @test ImgHdr.isa_tiff(tiff)
+    @test imgtype(tiff) == "tiff"
+    @test imgtype(tiff) != "png"
+
+    webp = "images/example.webp"
+    @test ImgHdr.isa_webp(webp)
+    @test imgtype(webp) == "webp"
+    @test imgtype(webp) != "gif"
+
+    pbm = "images/example.pbm"
+    @test ImgHdr.isa_pbm(pbm)
+    @test imgtype(pbm) == "pbm"
+    @test imgtype(pbm) != "png"
+
+    xbm = "images/example.xbm"
+    @test ImgHdr.isa_xbm(xbm)
+    @test imgtype(xbm) == "xbm"
+    @test imgtype(xbm) != "gif"
+
+    bmp = "images/example.bmp"
+    @test ImgHdr.isa_bmp(bmp)
+    @test imgtype(bmp) == "bmp"
+    @test imgtype(bmp) != "png"
+
+    pgm = "images/example.pgm"
+    @test ImgHdr.isa_pgm(pgm)
+    @test imgtype(pgm) == "pgm"
+    @test imgtype(pgm) != "gif"
+
+    ppm = "images/example.ppm"
+    @test ImgHdr.isa_ppm(ppm)
+    @test imgtype(ppm) == "ppm"
+    @test imgtype(ppm) != "png"
+
+    rast = "images/example.ras"
+    @test ImgHdr.isa_rast(rast)
+    @test imgtype(rast) == "rast"
+    @test imgtype(rast) != "gif"
+
+    rgb = "images/example.rgb"
+    @test ImgHdr.isa_ppm(rgb)
+    @test imgtype(rgb) == "rgb"
+    @test imgtype(rgb) != "png"
+    
+    not = "images/not-a-image.txt"
+    @test ImgHdr.isa_ppm(not) == false
+    @test imgtype(not) == nothing
 end 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using ImgHdr
 using ImgHdr: imgtype
 using Test: @testset, @test, @test_throws
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,7 +65,7 @@ using Test: @testset, @test, @test_throws
     @test imgtype(rast) != "gif"
 
     rgb = "images/example.rgb"
-    @test ImgHdr.isa_ppm(rgb)
+    @test ImgHdr.isa_rgb(rgb)
     @test imgtype(rgb) == "rgb"
     @test imgtype(rgb) != "png"
     


### PR DESCRIPTION
1. Make `what` an implementation detail `_read`. In original python module `what` is the checking function, not just for read, in this case `what` makes no sense to me to describe what the function is doing. `check` is now `imgtype`, see below.
2. Docstrings go above objects, unlike in python, in julia any variable can be documented, not just function/methods, classes/structs and modules.

```julia
julia> @doc "the answer to life the universe and everything" ->
       x = 42
x

help?> x
search: x xor exp Expr exp2 exit axes expm1 exp10 export extrema exponent Exception expanduser ExponentialBackOff max Text nextpow nextind maximum nextprod

  the answer to life the universe and everything
```

In this example I need to use `@doc ... -> obj` in the REPL to attach the docstring, but not in the REPL this would suffice:

```julia
"the answer to life the universe and everything"
x = 42
```

3. Do not print anything when importing the module as a library.
4. Add vertical spacing and other whitespace style.
5. Change `check` to `imgtype`. as it is exported can be used without `ImgHdr.check`, like so `check`, in this case it is not evident what it is checking, `imgtype` is a bit better, IMHO.

```julia
julia> using ImgHeader: imgtype

julia> foo = "some/foo/bar.png"

julia> imgtype(foo)
"png"

julia> ImgHdr.isa_png(foo)
true
```
This could also be exported or not, but I think it is useful to allow each check function to be called independently as well, so also change `test_foo` for `isa_foo`, due to Julia convention in naming these kind of boolean functions in Base.